### PR TITLE
feat(cli): add `-g` cli argument to specify how many gpus used in one node

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -11,18 +11,26 @@
 #include "md_hip_config.h"
 
 unsigned int batches_cli = 1;
+unsigned int gpu_num_per_node = 1;
 
 args::ValueFlag<unsigned int> *flag_batches;
+args::ValueFlag<unsigned int> *flag_gpus_per_node;
 
 void hip_cli_options(args::ArgumentParser &parser) {
   // todo delete
   flag_batches = new args::ValueFlag<unsigned int>(parser, "batches", "batches", {'b', "Batches number"});
+  flag_gpus_per_node = new args::ValueFlag<unsigned int>(
+      parser, "gpus_per_node", "specify how many gpus used in one node", {'g', "gpus_per_node"});
 }
 
 bool hip_cli_options_parse(args::ArgumentParser &) {
   if (*flag_batches) {
     batches_cli = args::get(*flag_batches);
   }
+  if (*flag_gpus_per_node) {
+    gpu_num_per_node = args::get(*flag_gpus_per_node);
+  }
+
 #ifdef USE_NEWTONS_THIRD_LAW
   constexpr bool use_newtons_third_law = true;
 #endif

--- a/src/cli.h
+++ b/src/cli.h
@@ -9,5 +9,6 @@
  * batches number read from cli.
  */
 extern unsigned int batches_cli;
+extern unsigned int gpu_num_per_node;
 
 #endif // MISA_MD_HIP_CLI_H


### PR DESCRIPTION
By specifying `-g` to set GPUs used in one node, we can bind MPI ranks and devices.

The assignment rule is:
(device id used for the MPI rank) = (local MPI rank_id on node) % (value of `-g`). Please note, one GPU device may assign multile MPI ranks if MPI ranks on a node > GPUs on the node.

In past version, we can only use one GPU deivce (device id=0) on a node. After this commit, we can use multiple GPU devices on the node.